### PR TITLE
improve: pass meta data of chunk to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 var posthtml = require('posthtml');
 var through = require('through2');
 var gutil = require('gulp-util');
+var objectAssign = require('object-assign');
 var PluginError = gutil.PluginError;
 
 // Consts
 var PLUGIN_NAME = 'gulp-posthtml';
+
+function getMetaInfoFromChunk(chunk) {
+  return {
+    path: chunk.path
+  }
+}
 
 module.exports = function(plugins, options) {
 
@@ -18,7 +25,8 @@ module.exports = function(plugins, options) {
           return cb(null, chunk);
         }
         posthtml([].concat(plugins))
-            .process(String(chunk.contents), options)
+            .process(String(chunk.contents),
+                objectAssign({}, options, getMetaInfoFromChunk(chunk)))
             .then(function(result) {
                 chunk.contents = new Buffer(result.html);
                 cb(null, chunk);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "gulp-util": "^3.0.6",
+    "object-assign": "^4.0.1",
     "posthtml": "^0.8.0",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
this is need by my posthtml plugin [posthtml-web-component](https://github.com/island205/posthtml-web-component)

say as I have an `index.html`:

``` html
<!doctype html>
<html>
<head>

    <meta charset="utf-8">
    <title>hello-world</title>

    <!-- Imports custom element -->
    <link rel="import" href="./hello-world.html">

</head>
<body>

    <!-- Runs custom element -->
    <hello-world></hello-world>

</body>
</html>
```

if i want get the real path of  `hello-world.html` in `<link rel="import" href="./hello-world.html">`, i need to kown the real path of `index.html`.

How?

Working with jade, well, one `posthtml` instance handle one file, i can pass the `path` by `options` passed to the plugin.

```
var posthtml = require('posthtml')
module.exports = function (path, options, callback) {

    var html = require('ejs').renderFile(path, options, function(err, html) {
      if (err) {
        return callback(err)
      }
      posthtml([
        require('../src/index')({
          hostURI:path
        })
      ])
          .process(html)
          .then(function (result) {
              if (typeof callback === 'function') {
                  var res;
                  try {
                      res = result.html;
                  } catch (ex) {
                      return callback(ex);
                  }
                  return callback(null, res);
              }
          });
    });
}
```

but when come to `gulp-posthtml`, i can't. `options` pass to plugin only pass once, and i don't kown the real path of `index.html`, until in the gulp stream.

so my workaround is pass the real path by `options` in the `.process(tree, options)` call, pass it to the `tree.options`.
